### PR TITLE
Connect mongodb and add setPrefix command

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   Ping: require('./ping'),
+  SetPrefix: require('./setPrefix'),
   SetReminders: require('./setReminders'),
 };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -5,5 +5,6 @@ module.exports = {
   description: 'Ping!',
   execute(msg, args) {
     msg.channel.send('Pong!');
+    console.log(config); // For debugging
   },
 };

--- a/commands/setPrefix.js
+++ b/commands/setPrefix.js
@@ -1,0 +1,27 @@
+const config = require('../config');
+const Guild = require('../models/Guild');
+
+module.exports = {
+  name: 'setPrefix',
+  description: 'User command to change prefix for this bot',
+  async execute(msg, args) {
+    // TODO: Add validation, the prefix should be max length of 1
+    const newPrefix = args[0];
+
+    // Update the databse
+    await Guild.findByIdAndUpdate(msg.guild.id, { prefix: newPrefix }, async (err, guild) => {
+      if (err) {
+        console.error(err);
+      }
+      if (!guild) {
+        await Guild.create({ _id: msg.guild.id, prefix: newPrefix });
+      }
+    });
+
+    // Update local config
+    config.guilds[msg.guild.id] = config.guilds[msg.guild.id] || {};
+    config.guilds[msg.guild.id].prefix = newPrefix;
+
+    msg.channel.send(`Hydro Pump prefix changed to ${newPrefix}`);
+  },
+};

--- a/commands/setReminders.js
+++ b/commands/setReminders.js
@@ -1,41 +1,50 @@
 const config = require('../config');
-const cron = require('node-cron');
+const Guild = require('../models/Guild');
+const Helpers = require ('../helpers');
 
 module.exports = {
   name: 'setReminders',
   description: 'User command to set channel for bot to regularly notify',
   async execute(msg, args) {
     // TODO: add validation for arguments
-    config.notificationChannelId = args[0].replace(/[^0-9]/g, '');
+    const notificationChannelId = args[0].replace(/[^0-9]/g, '');
+    var cronSchedule = '';
+
     switch(args[1]) {
       case 'hourly':
-        config.cronSchedule = '0 0 * * * *';
+        cronSchedule = '0 0 * * * *';
         break;
       case 'daily':
-        config.cronSchedule = '0 0 14 * * *';
+        cronSchedule = '0 0 14 * * *';
+        break;
+      case 'dev':
+        cronSchedule = '* * * * *';
     }
-    msg.channel.send(`Notification channel set to ${args[0]}, with ${args[1]} reminders!`);
 
-    // Schedule reminders to the channel
-    let notificationChannel = await msg.client.channels.fetch(config.notificationChannelId);
-    let task = cron.schedule(config.cronSchedule, () => {
-      notificationChannel.send(`Remember to stay hydrated! \nReact with 💧 in the next 5 minutes if you drank some water!`).then(msg => {
-        msg.react('💧');
-        const filter = reaction => reaction.emoji.name === '💧';
-        const collector = msg.createReactionCollector(filter, { time: 5 * 60 * 1000 });
-        collector.on('collect', reaction => console.log(`Collected ${reaction.emoji.name}`));
-        collector.on('end', collected => console.log(`Collected ${collected.size} items`));
-      });
+    // Update the database
+    await Guild.findByIdAndUpdate(msg.guild.id, {
+      cronSchedule: cronSchedule,
+      notificationChannelId: notificationChannelId,
+    }, async (err, guild) => {
+      if (err) {
+        console.error(err);
+      }
+      if (!guild) {
+        await Guild.create({
+          _id: msg.guild.id,
+          cronSchedule: cronSchedule,
+          notificationChannelId: notificationChannelId,
+        });
+      }
     });
 
-    // Destroy any existing cron jobs
-    let existingTask = config.cronJobMap[msg.guild.id];
-    if (existingTask) {
-      existingTask.destroy();
-    }
+    // Update local config
+    config.guilds[msg.guild.id] = config.guilds[msg.guild.id] || {};
+    config.guilds[msg.guild.id].notificationChannelId = notificationChannelId;
+    config.guilds[msg.guild.id].cronSchedule = cronSchedule;
 
-    // Start task, then save it to map
-    task.start();
-    config.cronJobMap[msg.guild.id] = task;
+    Helpers.startCronJob(msg.client, msg.guild.id, notificationChannelId, cronSchedule);
+
+    msg.channel.send(`Notification channel set to ${args[0]}, with ${args[1]} reminders!`);
   },
 };

--- a/config.js
+++ b/config.js
@@ -1,7 +1,14 @@
-// User variables
+/*
+ * Global config file
+ * Stores a map of guilds, each with
+ * - _id (String, unique Discord ID)
+ * - prefix (String, prefix for commands)
+ * - notificationChannelId (String, ID of channel to send messages to)
+ * - cronSchedule (String, cron representation of when to send reminders)
+ * - cronJob (cron.ScheduledTask, a scheduled task using the node-cron package)
+ *
+ * Nearly all the properties of a guild object are populated by an initial call to the database on bot startup, except cronJob. This is generated on startup with a helper function that takes notifactionChannelId and cronSchedule to create a cron.ScheduledTask.
+ */
 module.exports = {
-  cronSchedule: '* * * * * *', // second (optional), minute, hour, day of month, month, day of month
-  cronJobMap: {},
-  notificationChannelId: '',
-  prefix: '!',
+  guilds: {},
 };

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,36 @@
+const cron = require('node-cron');
+const config = require('./config');
+
+const startCronJob = async function (client, guildId, notificationChannelId, cronSchedule) {
+  // Find channel and schedule the cronJob
+  client.channels.fetch(notificationChannelId)
+    .then((channel) => {
+      console.log(`Scheduling cronJob for guild ${guildId} with cronSchedule ${cronSchedule}`);
+      const task = cron.schedule(cronSchedule, () => {
+        channel.send(`Remember to stay hydrated! \nReact with 💧 in the next 5 minutes if you drank some water!`).then(msg => {
+          msg.react('💧');
+          const filter = reaction => reaction.emoji.name === '💧';
+          const collector = msg.createReactionCollector(filter, { time: 5 * 60 * 1000 });
+          collector.on('collect', reaction => console.log(`Collected ${reaction.emoji.name}`));
+          collector.on('end', collected => console.log(`Collected ${collected.size} items`));
+        });
+      });
+
+      // Destroy any previously existing cronJob
+      const existingTask = config?.guilds[guildId]?.cronJob;
+      if (existingTask) {
+        existingTask.destroy();
+      }
+
+      // Start the new task and save it to the local config
+      task.start();
+      config.guilds[guildId] = config.guilds[guildId] || {};
+      config.guilds[guildId].cronJob = task;
+    }).catch((err) => {
+      console.error(err);
+    });
+};
+
+module.exports = {
+  startCronJob,
+};

--- a/index.js
+++ b/index.js
@@ -1,36 +1,79 @@
 require('dotenv').config();
 const Discord = require('discord.js');
-const bot = new Discord.Client();
-bot.commands = new Discord.Collection();
+const mongoose = require('mongoose');
+const client = new Discord.Client();
+client.commands = new Discord.Collection();
 
-const botCommands = require('./commands');
+const clientCommands = require('./commands');
 const config = require('./config');
+const Guild = require('./models/Guild');
+const Helpers = require('./helpers');
 
-Object.keys(botCommands).map(key => {
-  bot.commands.set(botCommands[key].name, botCommands[key]);
+// Connect to MongoDB with Mongoose
+const uri = `mongodb+srv://${process.env.DB_USER}:${process.env.DB_PASS}@cluster0.gmyc8.mongodb.net/hydro-pump?retryWrites=true&w=majority`
+mongoose.connect(uri, {
+  useFindAndModify: false,
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+}).then(() => {
+  console.info('MongoDB connected!')
+}).catch((err) => {
+  console.error('Error connecting to MongoDB')
+  console.error(err)
 });
 
-const TOKEN = process.env.TOKEN;
-bot.login(TOKEN);
-
-bot.on('ready', () => {
-  console.info(`Logged in as ${bot.user.tag}!`);
+// Map commands
+Object.keys(clientCommands).map(key => {
+  console.log(`Setting up ${clientCommands[key].name}`);
+  client.commands.set(clientCommands[key].name, clientCommands[key]);
 });
 
-bot.on('message', msg => {
-  if (msg.content[0] === config.prefix) {
+// Startup functions
+client.once('ready', () => {
+  console.info(`Logged in as ${client.user.tag}!`);
+
+  // Fetch all guilds from database and populate local config
+  Guild.find({})
+  .then((guilds) => {
+    console.info('Populating local config and scheduling cronJobs...');
+    guilds.forEach((guild) => {
+      if (guild.notificationChannelId && guild.cronSchedule) {
+        Helpers.startCronJob(client, guild._id, guild.notificationChannelId, guild.cronSchedule);
+      }
+      config.guilds[guild._id] = {
+        prefix: guild.prefix,
+        notificationChannelId: guild.notificationChannelId,
+        cronSchedule: guild.cronSchedule,
+      };
+    });
+    console.info('Guilds fetched from database and added to local config');
+  }).catch((err) => {
+    console.err('Error fetching from database');
+    console.err(err);
+  });
+});
+
+// Message listener
+client.on('message', msg => {
+  const prefix = config.guilds[msg.guild.id]?.prefix || '!';
+
+  if (msg.content[0] === prefix) {
     const args = msg.content.split(/ +/);
     const command = args.shift().substring(1);
 
-    if (!bot.commands.has(command)) {
+    if (!client.commands.has(command)) {
       msg.channel.send('This command does not exist!')
     } else {
       try {
-        bot.commands.get(command).execute(msg, args);
+        client.commands.get(command).execute(msg, args);
       } catch (error) {
         console.error(error);
-        msg.reply('there was an error trying to execute that command!');
+        msg.reply('There was an error trying to execute that command!');
       }
     }
   }
 });
+
+// Start Discord client!
+const TOKEN = process.env.TOKEN;
+client.login(TOKEN);

--- a/models/Guild.js
+++ b/models/Guild.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose')
+
+const GuildSchema = new mongoose.Schema({
+  _id: String,
+  prefix: String,
+  notificationChannelId: String,
+  cronSchedule: String,
+});
+
+const Guild = mongoose.model('Guild', GuildSchema)
+
+module.exports = Guild;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,28 @@
         "mime-types": "^2.1.12"
       }
     },
+    "@types/bson": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
+      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/mongodb": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.5.tgz",
+      "integrity": "sha512-XbG9+2wNaEwUn5DlhgN4ogjUYYzvjIsH6gwPvXXoTgfiQqUNq41RNxOqO+lrdpCjlRKtt/Pv7ZgSl7paQ/GUjw==",
+      "requires": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -32,6 +54,25 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "bson": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -40,10 +81,35 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "discord.js": {
       "version": "12.5.1",
@@ -70,6 +136,27 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "kareem": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "mime-db": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
@@ -82,6 +169,72 @@
       "requires": {
         "mime-db": "1.45.0"
       }
+    },
+    "mongodb": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "5.11.15",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.11.15.tgz",
+      "integrity": "sha512-8T4bT6eCGB7MqCm40oVhnhT/1AyAdwe+y1rYUhdl3ljsks3BpYz8whZgcMkIoh6VoCCjipOXRqZqdk1UByvlYA==",
+      "requires": {
+        "@types/mongodb": "^3.5.27",
+        "bson": "^1.1.4",
+        "kareem": "2.3.2",
+        "mongodb": "3.6.3",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.8.3",
+        "mquery": "3.2.3",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mpath": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
+      "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA=="
+    },
+    "mquery": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.3.tgz",
+      "integrity": "sha512-cIfbP4TyMYX+SkaQ2MntD+F2XbqaBHUYWk3j+kqdDztPWok3tgyssOZxMHMtzbV1w9DaSlvEea0Iocuro41A4g==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "^1.0.0",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-cron": {
       "version": "2.0.3",
@@ -107,10 +260,108 @@
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.3.tgz",
       "integrity": "sha512-fSrR66n0l6roW9Rx4rSLMyTPTjRTiXy5RVqDOurACQ6si1rKHHKDU5gwBJoCsIV0R3o9gi+K50akl/qyw1C74A=="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "tweetnacl": {
       "version": "1.0.3",
@@ -121,6 +372,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tz-offset/-/tz-offset-0.0.1.tgz",
       "integrity": "sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "ws": {
       "version": "7.4.2",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "dependencies": {
     "discord.js": "^12.5.1",
     "dotenv": "^8.2.0",
+    "mongoose": "^5.11.15",
     "node-cron": "^2.0.3"
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
![](https://media.giphy.com/media/slVWEctHZKvWU/giphy.gif)

## Description
This is a chonky PR I should have broken up into commits, but it took a while to get all the pieces working and, well, it's just me working on this. Let's go over what exactly is happening here.

### Welcome MongoDB
Not sure if this is the _best_ way to go about this, but I've decided to use MongoDB as persistent storage for guild configurations. A guild represents a Discord server, and each one has a unique ID. There is a cluster of `Guild` documents, each with the schema defined in `Guild.js`.

At startup, Hydro Pump fetches guilds from its collection and can retain information (eg. prefixes, scheduled messages). If the bot restarts then it will have every guild's configuration saved. As such, there was a refactoring of the local config file (`config.js`). Now it's pretty much an object with a map of Guilds, closely matching the Guild schema.

### `setPrefix`
The prefix for listening to messages is now configurable. You can do so by running the command:
```
!setPrefix <newPrefix>
```
(If you've changed the prefix before, you will need to swap `!` out for that)